### PR TITLE
Make public unwrapped

### DIFF
--- a/shape.go
+++ b/shape.go
@@ -292,6 +292,10 @@ func (s *BaseShape) IsUnwrapped() bool {
 	return s.unwrapped
 }
 
+func (s *BaseShape) SetUnwrapped() {
+	s.unwrapped = true
+}
+
 func (s *BaseShape) IsScalar() bool {
 	// TODO: Implement in Shape interface
 	switch s.Shape.(type) {


### PR DESCRIPTION
Required by ad-hoc processors that implement custom unwrapping function. This is temporary until a separate pipeline interface is implemented.