### PR TITLE
Remove inheritance of custom properties

### DIFF
--- a/shape.go
+++ b/shape.go
@@ -127,18 +127,6 @@ func (s *BaseShape) Inherit(sourceBase *BaseShape) (*BaseShape, error) {
 	if err := s.callRAMLHooks(HookBeforeBaseShapeInherit, sourceBase); err != nil {
 		return nil, err
 	}
-	for pair := sourceBase.CustomShapeFacets.Oldest(); pair != nil; pair = pair.Next() {
-		k, item := pair.Key, pair.Value
-		if _, ok := s.CustomShapeFacets.Get(k); !ok {
-			s.CustomShapeFacets.Set(k, item)
-		}
-	}
-	for pair := sourceBase.CustomDomainProperties.Oldest(); pair != nil; pair = pair.Next() {
-		k, item := pair.Key, pair.Value
-		if _, ok := s.CustomDomainProperties.Get(k); !ok {
-			s.CustomDomainProperties.Set(k, item)
-		}
-	}
 
 	source := sourceBase.Shape
 	target := s.Shape


### PR DESCRIPTION
Custom annotations are not inherited in Data Types according to the [Annotations section](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md/#annotations). 

This also removes the inheritance of custom facets as the semantics of those facets are not understood by the standard processor. The specification does not clearly state whether those are inherited, but it seems that their inheritance should follow the same rules as custom annotations.